### PR TITLE
Add example mac overlay agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# computer-use-agent
+# Computer Use Agent
+
+This repository contains a small example of a "computer use" agent for macOS.
+The agent is written in Python and displays a minimal overlay similar to the
+Spotlight search bar. When you type a natural language request in the overlay,
+it generates AppleScript code and executes it using `osascript`.
+
+## Requirements
+
+- macOS system with Python 3.
+- Tkinter (usually included with Python on macOS).
+
+## Usage
+
+Run the agent with:
+
+```bash
+python mac_overlay_agent.py
+```
+
+An overlay window will appear. Type a simple command such as `open Safari` or
+`new note`. The agent will display the generated AppleScript and attempt to run
+it. The included `nl_to_applescript` function supports only a few basic
+examples, but you can extend it or integrate a language model API for more
+advanced behavior.

--- a/mac_overlay_agent.py
+++ b/mac_overlay_agent.py
@@ -1,0 +1,68 @@
+import tkinter as tk
+import subprocess
+
+
+def nl_to_applescript(request: str) -> str:
+    """Naive translator from natural language request to AppleScript.
+
+    This placeholder function implements a couple of example commands. In a real
+    agent you might integrate a language model API or a more sophisticated
+    parser to generate AppleScript dynamically.
+    """
+    lower = request.lower()
+    if "open safari" in lower:
+        return 'tell application "Safari" to activate'
+    if "new note" in lower:
+        return 'tell application "Notes" to make new note with properties {body:""}'
+    # Default fallback script shows a dialog
+    return f'display dialog "Cannot handle request: {request}"'
+
+
+class OverlayAgent(tk.Tk):
+    """Simple overlay agent similar to Spotlight search."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Overlay Agent")
+        self.attributes('-topmost', True)
+        self.configure(bg='black')
+        self.overrideredirect(True)
+        self.geometry('600x50+400+200')
+
+        self.entry = tk.Entry(self, bg='black', fg='white', insertbackground='white', font=('Helvetica', 14))
+        self.entry.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+        self.entry.bind('<Return>', self.process_request)
+
+        self.output = tk.Text(self, height=10, bg='black', fg='white', insertbackground='white', font=('Helvetica', 12))
+        self.output.pack(fill=tk.BOTH, expand=True, padx=10, pady=(0, 10))
+        self.output.config(state=tk.DISABLED)
+
+    def process_request(self, event=None) -> None:
+        request = self.entry.get()
+        self.entry.delete(0, tk.END)
+        applescript = nl_to_applescript(request)
+        self.display_applescript(applescript)
+        self.run_applescript(applescript)
+
+    def display_applescript(self, script: str) -> None:
+        self.output.config(state=tk.NORMAL)
+        self.output.delete(1.0, tk.END)
+        self.output.insert(tk.END, script)
+        self.output.config(state=tk.DISABLED)
+
+    def run_applescript(self, script: str) -> None:
+        # Execute the generated AppleScript using osascript
+        try:
+            subprocess.run(["osascript", "-e", script], check=False)
+        except FileNotFoundError:
+            # On non-macOS platforms osascript will not exist. Ignore errors.
+            pass
+
+
+def main() -> None:
+    agent = OverlayAgent()
+    agent.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a simple macOS overlay agent in Python that translates requests to AppleScript
- document usage in README

## Testing
- `python3 -m py_compile mac_overlay_agent.py`


------
https://chatgpt.com/codex/tasks/task_e_685aaef288b083259db2829fed455609